### PR TITLE
Add age verification gate overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,104 @@
       line-height: 1.6;
     }
 
+    body.no-scroll {
+      overflow: hidden;
+    }
+
     a {
       color: inherit;
       text-decoration: none;
+    }
+
+    .age-gate {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.78);
+      backdrop-filter: blur(6px);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      z-index: 9999;
+    }
+
+    .age-gate[aria-hidden="false"] {
+      display: flex;
+    }
+
+    .age-gate__dialog {
+      max-width: 420px;
+      width: min(100%, 420px);
+      background: var(--surface);
+      border-radius: 24px;
+      padding: 2.5rem 2.25rem;
+      box-shadow: 0 32px 60px rgba(15, 23, 42, 0.25);
+      text-align: center;
+      position: relative;
+    }
+
+    .age-gate__badge {
+      width: 70px;
+      height: 70px;
+      border-radius: 50%;
+      margin: 0 auto 1.5rem;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      font-size: 1.5rem;
+      color: #fff;
+      background: var(--accent);
+    }
+
+    .age-gate__title {
+      font-size: 1.75rem;
+      margin: 0 0 0.75rem;
+      color: var(--brand-dark);
+    }
+
+    .age-gate__text {
+      color: var(--muted);
+      margin: 0 0 1.75rem;
+    }
+
+    .age-gate__actions {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .age-gate__confirm,
+    .age-gate__exit {
+      border: none;
+      border-radius: 999px;
+      padding: 0.85rem 1.25rem;
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .age-gate__confirm {
+      background: var(--accent);
+      color: #fff;
+      box-shadow: 0 16px 32px rgba(92, 78, 214, 0.24);
+    }
+
+    .age-gate__confirm:hover,
+    .age-gate__confirm:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 20px 40px rgba(92, 78, 214, 0.28);
+    }
+
+    .age-gate__exit {
+      background: var(--surface);
+      color: var(--brand-dark);
+      border: 1px solid rgba(124, 58, 237, 0.25);
+    }
+
+    .age-gate__exit:hover,
+    .age-gate__exit:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 18px 28px rgba(15, 23, 42, 0.12);
     }
 
     .top-bar {
@@ -377,6 +472,19 @@
   </style>
 </head>
 <body>
+  <div class="age-gate" id="ageGate" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="age-gate__dialog">
+      <div class="age-gate__badge" aria-hidden="true">18+</div>
+      <h1 class="age-gate__title">Adults only</h1>
+      <p class="age-gate__text">
+        Eciggy UK sells vaping products intended strictly for adults. Please confirm that you are 18 years of age or older to enter.
+      </p>
+      <div class="age-gate__actions">
+        <button type="button" class="age-gate__confirm" id="ageGateConfirm">I am 18 or older</button>
+        <button type="button" class="age-gate__exit" id="ageGateExit">Leave site</button>
+      </div>
+    </div>
+  </div>
   <div class="top-bar">
     <span>Free UK delivery on orders over £30</span>
     <span>Questions? Call 0330 043 9980</span>
@@ -579,6 +687,43 @@
   </footer>
   <script>
     document.getElementById("year").textContent = new Date().getFullYear();
+
+    (function () {
+      const gate = document.getElementById("ageGate");
+      const confirmBtn = document.getElementById("ageGateConfirm");
+      const exitBtn = document.getElementById("ageGateExit");
+
+      if (!gate || !confirmBtn || !exitBtn) {
+        return;
+      }
+
+      const storageKey = "eciggy-age-verified";
+      const hasVerified = window.localStorage.getItem(storageKey) === "true";
+
+      const showGate = () => {
+        gate.setAttribute("aria-hidden", "false");
+        document.body.classList.add("no-scroll");
+        confirmBtn.focus();
+      };
+
+      const hideGate = () => {
+        gate.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("no-scroll");
+      };
+
+      if (!hasVerified) {
+        showGate();
+      }
+
+      confirmBtn.addEventListener("click", () => {
+        window.localStorage.setItem(storageKey, "true");
+        hideGate();
+      });
+
+      exitBtn.addEventListener("click", () => {
+        window.location.href = "https://www.google.com";
+      });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an age verification modal overlay that blocks access until users confirm they are 18 or older
- style the modal to match the site's branding and prevent scrolling while active
- persist verification with localStorage and provide an exit link for underage visitors

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbdb354f908333aa4c934636fac43c