### PR TITLE
Add Eciggy shortfill product pages with new flavour grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,6 +350,60 @@
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
+    .flavour-grid {
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .flavour-card {
+      background: var(--surface);
+      border-radius: 24px;
+      box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+      overflow: hidden;
+      display: grid;
+    }
+
+    .flavour-card img {
+      width: 100%;
+      height: 220px;
+      object-fit: cover;
+    }
+
+    .flavour-card__body {
+      padding: 1.75rem;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .flavour-card__body h3 {
+      margin: 0;
+      color: #111827;
+      font-size: 1.25rem;
+    }
+
+    .flavour-card__body p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .flavour-card__cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 600;
+      color: var(--brand-dark);
+    }
+
+    .flavour-card__cta::after {
+      content: "→";
+      transition: transform 0.2s ease;
+    }
+
+    .flavour-card:hover .flavour-card__cta::after {
+      transform: translateX(4px);
+    }
+
     .card {
       background: var(--surface);
       padding: 1.75rem;
@@ -617,6 +671,77 @@
           <h3>Big bottles, bold taste</h3>
           <p>Add nic shots for tailored strengths and enjoy layered flavour profiles.</p>
         </article>
+      </div>
+    </section>
+
+    <section id="shortfills">
+      <h2>Eciggy Signature Shortfill Range</h2>
+      <p class="lead">Pair our new artwork collection with detailed product guides for every flavour in the Eciggy line-up.</p>
+      <div class="flavour-grid">
+        <a class="flavour-card" href="products/blackcurrant.html">
+          <img src="blackcurrant.png" alt="Eciggy Blackcurrant Burst shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Blackcurrant Burst</h3>
+            <p>Woodland berries chilled with a frosty exhale.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/bubblegum.html">
+          <img src="bubblegum.png" alt="Eciggy Bubblegum Blitz shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Bubblegum Blitz</h3>
+            <p>Nostalgic candy sweetness with a cool twist.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/cherrycola.html">
+          <img src="cherrycola.png" alt="Eciggy Cherry Cola Fizz shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Cherry Cola Fizz</h3>
+            <p>Sparkling cola syrup with dark cherry depth.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/fruitilicious.html">
+          <img src="fruitilicious.png" alt="Eciggy Fruiti-Licious Punch shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Fruiti-Licious Punch</h3>
+            <p>Tropical medley of pineapple, mango and kiwi.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/jackblack.html">
+          <img src="jackblack.png" alt="Eciggy Jack Black shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Jack Black</h3>
+            <p>Aniseed and liquorice with a menthol lift.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/lemonsherbet.html">
+          <img src="lemonsherbet.png" alt="Eciggy Lemon Sherbet Pop shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Lemon Sherbet Pop</h3>
+            <p>Zingy lemon candy with fizzy sherbet.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/strawgasm.html">
+          <img src="strawgasm.png" alt="Eciggy Strawgasm shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Strawgasm</h3>
+            <p>Strawberries and cream dessert clouds.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
+        <a class="flavour-card" href="products/watermelon.html">
+          <img src="watermelon.png" alt="Eciggy Watermelon Wave shortfill bottle" />
+          <div class="flavour-card__body">
+            <h3>Watermelon Wave</h3>
+            <p>Refreshing melon blend with icy finish.</p>
+            <span class="flavour-card__cta">View product</span>
+          </div>
+        </a>
       </div>
     </section>
 

--- a/products/blackcurrant.html
+++ b/products/blackcurrant.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Blackcurrant Burst Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Blackcurrant Burst</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../blackcurrant.png" alt="Eciggy Blackcurrant Burst shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Blackcurrant Burst 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            A bold, syrupy blackcurrant inhale wrapped in a chilled exhale for vapers craving berry intensity without the sweetness overload.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Includes two optional 18mg nic shots for 3mg mix.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>120ml shortfill bottle with 100ml e-liquid</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Add up to 20ml nic shot for a smooth 3mg finish</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG crafted for dense clouds</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Eciggy Blackcurrant Burst balances tart woodland berries with a cool finish that stays refreshing all day long. Every pull is layered to keep your tastebuds engaged from inhale to exhale.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Freshly picked blackcurrants with a juicy pop and gentle sweetness.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Ripple of frosty menthol to lift the berries and deliver a clean finish.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Lingering berry jam note balanced by a whisper of coolness.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Why Vapers Love Eciggy Shortfills</h2>
+        <ul>
+          <li>Premium UK-mixed e-liquid made in ISO-certified facilities.</li>
+          <li>100ml shortfill size keeps you stocked for longer sessions.</li>
+          <li>Precision 70/30 ratio for flavourful sub-ohm performance.</li>
+          <li>Nic-shot ready with tamper-evident seal and easy-pour nozzle.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>How to Mix</h2>
+        <p>Remove the cap and nib, squeeze in your preferred nicotine shots, replace the top and shake vigorously for 30 seconds. Let the bottle settle for a few minutes to allow air bubbles to rise before vaping.</p>
+        <p>We recommend pairing Blackcurrant Burst with mesh sub-ohm coils between 50–70W for the fullest flavour.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/bubblegum.html
+++ b/products/bubblegum.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Bubblegum Blitz Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Bubblegum Blitz</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../bubblegum.png" alt="Eciggy Bubblegum Blitz shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Bubblegum Blitz 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Nostalgic pink bubblegum with a sprinkle of powdered sugar and a breezy cool finish — a playful all-day vape that never loses its flavour.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Includes two optional 18mg nic shots for a silky 3mg blend.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>100ml e-liquid in a 120ml unicorn bottle</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Space for two 10ml nic shots</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for dense yet smooth clouds</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Bubblegum Blitz captures the rush of the first chew. Mouth-watering candy notes stay sweet without overpowering, making this an easy go-to for high wattage setups.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Classic bubblegum syrup with hints of strawberry and banana candy.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Cooling breeze keeps the sweetness in check and refreshes the palate.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Light icing sugar finish reminiscent of your favourite corner-shop gum.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Compatibility &amp; Setup</h2>
+        <ul>
+          <li>Ideal for sub-ohm tanks and pod mods with low-resistance coils.</li>
+          <li>Works brilliantly between 55–65W on mesh coil kits.</li>
+          <li>No added sweetener overload – keeps coils fresher for longer.</li>
+          <li>Childproof cap and tamper seal for safe transport.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>Combine with two 18mg nicotine shots to reach a 3mg strength, or use salt nic for a smoother hit. Shake for at least 60 seconds and allow Bubblegum Blitz to breathe with the cap off for five minutes before your first fill.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/cherrycola.html
+++ b/products/cherrycola.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Cherry Cola Fizz Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Cherry Cola Fizz</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../cherrycola.png" alt="Eciggy Cherry Cola Fizz shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Cherry Cola Fizz 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Sparkling cola syrup stirred through with dark cherry and a zingy citrus twist. Every vape delivers a refreshing fizz sensation.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Bundle with nic shots for a 3mg blend at checkout.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>120ml recyclable bottle filled with 100ml e-liquid</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Designed for two nic shots without reducing flavour</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for smooth fizzing clouds</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Cola-inspired vapes can be hit or miss. Eciggy Cherry Cola Fizz nails the authentic soda kick with a deep cherry sweetness and subtle cooling exhale to mimic the ultimate refreshing sip.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Classic cola syrup with clove and cinnamon spice undertones.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Rich cherry cordial balanced with a squeeze of lime zest.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Effervescent fizz and cola bottle candy notes on the finish.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Good to Know</h2>
+        <ul>
+          <li>Suitable for sub-ohm tanks, RDAs and high-performance pod mods.</li>
+          <li>Sweet spot between 50–70W depending on your coil.</li>
+          <li>No dyes or unnecessary additives – just flavour-packed vapour.</li>
+          <li>Made and bottled in the UK under TPD-compliant standards.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>For a chilled cola slush effect, pair with a menthol nic shot. Shake vigorously after adding shots and leave to steep overnight for a perfectly blended soda vape.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/fruitilicious.html
+++ b/products/fruitilicious.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Fruiti-Licious Punch Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Fruiti-Licious Punch</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../fruitilicious.png" alt="Eciggy Fruiti-Licious Punch shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Fruiti-Licious Punch 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Tropical fruit medley bursting with juicy pineapple, ripe mango and a sparkle of kiwi. It's sunshine in a bottle for vapers chasing vibrant, layered blends.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Add nic shots to craft your perfect strength.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>100ml shortfill in a 120ml recyclable bottle</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Space for two 10ml nic or salt nic boosters</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for lush tropical plumes</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Fruiti-Licious Punch is built for fans of rainbow fruit blends. Each draw delivers waves of bright citrus, creamy mango and delicate berry to keep your palate guessing.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Sweet pineapple and mango sorbet with a splash of dragon fruit.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Refreshing kiwi and lychee accents with a breezy finish.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Lingering berry sweetness with hints of creamy guava.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Perfect For</h2>
+        <ul>
+          <li>Vapers who love all-day tropical blends.</li>
+          <li>Mesh coil tanks running between 55–70W.</li>
+          <li>Mixing with menthol nic shots for a chilled punch bowl.</li>
+          <li>Pairing with summer BBQs and sunny afternoons.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>Shake vigorously once nic shots are added and let the shortfill settle for ten minutes. For an extra juicy experience, leave the bottle open for a further five minutes to allow the flavours to bloom.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/jackblack.html
+++ b/products/jackblack.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Jack Black Aniseed Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Jack Black</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../jackblack.png" alt="Eciggy Jack Black shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Jack Black 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Bold aniseed, rich liquorice and a cooling blast combine in this cult-favourite blend inspired by classic black jack sweets.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Optional nic shots available to create a 3mg shortfill.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>100ml of e-liquid in a tactile 120ml bottle</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Room for two nic boosters or cooling shots</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for velvety liquorice clouds</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Jack Black is the grown-up sweets experience with a frosty twist. Expect layers of spice and sweetness that evolve with every puff.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Punchy aniseed and liquorice rope candy.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Cooling menthol that brightens the herbal notes.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Sweet sherbet finish with a lingering spice.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Vaper Notes</h2>
+        <ul>
+          <li>Pairs brilliantly with rebuildable tanks and mesh sub-ohm coils.</li>
+          <li>Best between 50–65W for peak flavour and smoothness.</li>
+          <li>Menthol lovers can add an extra ice nic shot without muting the sweets.</li>
+          <li>Compliant with UK regulations and manufactured in small batches.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>Add one nic shot for 1.5mg or two for 3mg. Shake for 60 seconds and let Jack Black breathe for five minutes to soften the menthol edge before filling your tank.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/lemonsherbet.html
+++ b/products/lemonsherbet.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Lemon Sherbet Pop Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Lemon Sherbet Pop</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../lemonsherbet.png" alt="Eciggy Lemon Sherbet Pop shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Lemon Sherbet Pop 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Zesty lemons dusted with sparkling sherbet crystals. This tangy-sweet favourite delivers a fizzy candy rush with every puff.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Grab nic shots for a 3mg mix option.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>100ml shortfill presented in a 120ml bottle</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Nic shot friendly with generous mixing space</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for bright, smooth vapour</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Lemon Sherbet Pop hits the sweet spot between tart and sugary. It's vibrant, fizzy and never dull — perfect for breaking through flavour fatigue.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Fresh lemon zest with a squeeze of Sicilian lemon juice.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Tingly sherbet and candy fizz.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Light powdered sugar and lingering citrus sparkle.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Why You'll Love It</h2>
+        <ul>
+          <li>Refreshing citrus profile ideal for summer vaping.</li>
+          <li>Balanced sweetness keeps coils happier for longer.</li>
+          <li>Excellent with menthol or ice nic shots for extra chill.</li>
+          <li>TPD-compliant and batch tested for quality.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>Add one nic shot to make 1.5mg or two for 3mg. Shake thoroughly for 45 seconds and leave the bottle upright with the cap loosely fitted for five minutes so the sherbet notes can settle.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/strawgasm.html
+++ b/products/strawgasm.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Strawgasm Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Strawgasm</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../strawgasm.png" alt="Eciggy Strawgasm shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Strawgasm 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Sweet strawberries and smooth cream collide in this decadent dessert vape. A bakery-style treat without the calories.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Optional nic shots available to tailor your strength.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>100ml shortfill supplied in a 120ml bottle</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Space for up to two nic shots</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for silky dessert clouds</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Strawgasm is built for dessert lovers. It's rich, layered and comforting — perfect as an after-dinner vape or a creamy all-day option.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Fresh strawberry coulis with a touch of powdered sugar.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Velvety whipped cream and vanilla custard.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Soft biscuit crumble and lingering strawberry sweetness.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Best Enjoyed With</h2>
+        <ul>
+          <li>High-wattage sub-ohm tanks between 60–75W.</li>
+          <li>Rebuildable dripping atomisers for dense dessert clouds.</li>
+          <li>Nic salt boosters for extra smooth throat hit.</li>
+          <li>A cosy evening in — Strawgasm is your dessert course.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>Add nic shots, shake for 60 seconds and let the bottle steep overnight to deepen the cream notes. For an instant treat, run a warm tap over the sealed bottle for a minute before shaking.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/products/watermelon.html
+++ b/products/watermelon.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eciggy Watermelon Wave Shortfill | Eciggy UK</title>
+    <link rel="stylesheet" href="../styles/product.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="logo-link" href="../index.html">
+        <img src="../logo.png" alt="Eciggy UK" />
+        <span>Eciggy UK</span>
+      </a>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <span>Watermelon Wave</span>
+      </nav>
+    </header>
+    <main>
+      <section class="product-hero">
+        <div class="product-media">
+          <img src="../watermelon.png" alt="Eciggy Watermelon Wave shortfill bottle" />
+        </div>
+        <div class="product-copy">
+          <span class="product-badge">Eciggy Signature Shortfill</span>
+          <h1 class="product-title">Watermelon Wave 100ml Shortfill</h1>
+          <p class="product-subtitle">
+            Juicy watermelon slices blended with a touch of cantaloupe and icy freshness. The ultimate summer refresher.
+          </p>
+          <div class="price-block">
+            <span class="price">£14.99</span>
+            <span class="price-note">Nic shot bundle available for a 3mg finish.</span>
+          </div>
+          <ul class="key-specs">
+            <li>
+              <strong>Bottle size:</strong>
+              <span>100ml shortfill presented in a 120ml bottle</span>
+            </li>
+            <li>
+              <strong>Nicotine ready:</strong>
+              <span>Add two 10ml nic shots with ease</span>
+            </li>
+            <li>
+              <strong>Blend:</strong>
+              <span>70% VG / 30% PG for refreshing clouds</span>
+            </li>
+          </ul>
+          <div class="actions">
+            <button class="button-primary">Add to Basket</button>
+            <button class="button-secondary">Add Nic Shot Bundle</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Flavour Breakdown</h2>
+        <p>
+          Watermelon Wave is crisp and clean, with cooling notes that make it perfect for hot days or when you need a quick palate reset.
+        </p>
+        <div class="tasting-grid">
+          <article class="tasting-card">
+            <h3>Inhale</h3>
+            <p>Sweet watermelon slices drenched in juice.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Exhale</h3>
+            <p>Melon medley with hints of honeydew and cantaloupe.</p>
+          </article>
+          <article class="tasting-card">
+            <h3>Aftertaste</h3>
+            <p>Refreshing ice finish and gentle fruit sweetness.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Why It Works</h2>
+        <ul>
+          <li>Cooling agent keeps things fresh without overpowering the fruit.</li>
+          <li>Perfect for day-long vaping thanks to balanced sweetness.</li>
+          <li>Pairs brilliantly with mesh coils or pod mod cartridges.</li>
+          <li>Made in the UK with traceable ingredients.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Mixing Tips</h2>
+        <p>Pop the cap, add your nic shots and shake vigorously. For the coldest experience, chill the shortfill in the fridge for ten minutes after mixing before filling your tank.</p>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-grid">
+        <div>
+          <h3>Eciggy UK</h3>
+          <p>Supplying vapers with bold flavours and trusted hardware since 2012.</p>
+        </div>
+        <div>
+          <h3>Need Help?</h3>
+          <p>Email <a href="mailto:hello@eciggyuk.co.uk">hello@eciggyuk.co.uk</a> or call <a href="tel:03300439980">0330 043 9980</a>.</p>
+        </div>
+        <div>
+          <h3>Stay Updated</h3>
+          <p>Join the Eciggy newsletter for flavour drops, bundle deals and expert advice.</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Eciggy UK. 18+ Only.</p>
+    </footer>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/styles/product.css
+++ b/styles/product.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light;
+  --brand: #08b0ff;
+  --brand-dark: #042340;
+  --brand-light: #e6f7ff;
+  --accent: linear-gradient(135deg, var(--brand), #00d1b2);
+  --text: #0f172a;
+  --muted: #475569;
+  --bg: #f2f7fc;
+  --surface: #ffffff;
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.site-header {
+  padding: 1.25rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--surface);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.logo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.125rem;
+}
+
+.logo-link img {
+  width: 44px;
+  height: 44px;
+  object-fit: contain;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+main {
+  flex: 1;
+}
+
+.product-hero {
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 6vw, 6rem);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(2rem, 5vw, 3.5rem);
+  align-items: center;
+}
+
+.product-media {
+  position: relative;
+}
+
+.product-media::before {
+  content: "";
+  position: absolute;
+  inset: 12% 10% 6% 10%;
+  background: var(--accent);
+  filter: blur(70px);
+  opacity: 0.35;
+  z-index: -1;
+}
+
+.product-media img {
+  width: min(360px, 100%);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 45px 75px rgba(4, 35, 64, 0.18);
+}
+
+.product-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(8, 176, 255, 0.15);
+  color: var(--brand-dark);
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+}
+
+.product-title {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  margin: 0 0 1rem;
+  color: var(--brand-dark);
+}
+
+.product-subtitle {
+  font-size: 1.1rem;
+  margin: 0 0 1.25rem;
+  color: var(--muted);
+}
+
+.price-block {
+  display: flex;
+  gap: 1rem;
+  align-items: baseline;
+  margin-bottom: 1.5rem;
+}
+
+.price-block .price {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--brand-dark);
+}
+
+.price-block .price-note {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.key-specs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.key-specs li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+  color: var(--muted);
+}
+
+.key-specs strong {
+  color: var(--brand-dark);
+}
+
+.button-primary,
+.button-secondary {
+  border-radius: 999px;
+  padding: 0.9rem 1.8rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.button-primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 18px 35px rgba(8, 176, 255, 0.25);
+}
+
+.button-secondary {
+  background: rgba(4, 35, 64, 0.08);
+  color: var(--brand-dark);
+}
+
+.button-primary:hover,
+.button-secondary:hover {
+  transform: translateY(-2px);
+}
+
+.section {
+  background: var(--surface);
+  margin: 0 clamp(1.25rem, 5vw, 6rem) clamp(2rem, 5vw, 3rem);
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.08);
+}
+
+.section + .section {
+  margin-top: clamp(1.5rem, 5vw, 2.5rem);
+}
+
+.section h2 {
+  margin-top: 0;
+  font-size: 1.65rem;
+  color: var(--brand-dark);
+}
+
+.section p {
+  margin-bottom: 1.2rem;
+  color: var(--muted);
+}
+
+.section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.section ul li {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(8, 176, 255, 0.08);
+  color: var(--brand-dark);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.section ul li::before {
+  content: "✔";
+  color: #00b894;
+  font-weight: 700;
+}
+
+.tasting-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1.25rem;
+}
+
+.tasting-card {
+  background: rgba(4, 35, 64, 0.05);
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+}
+
+.tasting-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.1rem;
+}
+
+footer {
+  margin-top: auto;
+  padding: 2.5rem clamp(1.5rem, 6vw, 6rem);
+  background: #03182e;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+footer a {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.8rem;
+}
+
+.footer-grid h3 {
+  margin-top: 0;
+  color: #fff;
+}
+
+.footer-bottom {
+  margin-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 1.5rem;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .site-header {
+    padding: 1rem 1.25rem;
+  }
+
+  .product-hero {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .section {
+    margin-inline: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated shortfill product pages for blackcurrant, bubblegum, cherry cola, fruiti-licious, jack black, lemon sherbet, strawgasm, and watermelon
- create shared styling for product detail pages and update the homepage with a shortfill flavour grid
- write flavour notes, specifications, and mixing guidance tailored to each e-liquid

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dbe1eefc6083338b183e84943ae8ae